### PR TITLE
Add Breeze AI documentation page

### DIFF
--- a/collections/_core-concepts/breeze-ai.md
+++ b/collections/_core-concepts/breeze-ai.md
@@ -1,0 +1,124 @@
+---
+layout: docs
+title: Breeze AI
+description: AI content generation, translation and MCP server for Magento admin
+order: 900
+---
+
+# Breeze AI
+
+* TOC
+{:toc}
+
+## About
+
+Breeze AI brings language models into the Magento admin. It's a part of
+[Breeze Enterprise](https://swissuplabs.com/magento-themes/magento-2-breeze-enterprise.html){:target="_blank" rel="noopener"}
+theme and consists from several parts:
+
+ -  AI Models --- connect one or more providers: OpenAI, Claude
+    ([Anthropic](https://www.anthropic.com/){:target="_blank" rel="noopener"}) and
+    Gemini (Google).
+ -  Prompts --- reusable prompt templates, assigned to the fields they generate.
+ -  AI Assistant --- generate or rewrite a single field right from the product,
+    category or CMS page edit form.
+ -  AI Bulk Action --- generate and translate content for many products or
+    categories at once, in the background.
+ -  MCP Server --- expose the store to AI coding agents over the
+    [Model Context Protocol](https://spec.modelcontextprotocol.io){:target="_blank" rel="noopener"}.
+
+## AI Models
+
+Start with the models. It's available for all Breeze Enterprise Theme customers
+under _Swissup > Breeze AI > Models_ menu. Add a model, pick the provider,
+paste the API key and mark one of them as default --- everything else in Breeze AI
+uses the default model unless a different one is chosen explicitly.
+
+<!-- TODO: screenshot --- Swissup > Breeze AI > Models grid, or the model form with provider select
+<img src="{{ '/assets/img/breeze-ai/models.webp?v=1' | relative_url }}" width="656" height="362" class="!m-0 rounded-lg shadow-lg" alt="AI Models Screenshot"/>
+-->
+
+## Prompts
+
+Prompts live under _Swissup > Breeze AI > Prompts_ menu. Every prompt is bound to
+the fields it may write to, so the AI Assistant and AI Bulk Action only offer the
+prompts that make sense for the field at hand.
+
+<!-- TODO: screenshot --- Swissup > Breeze AI > Prompts grid, or the prompt form with the field assignment
+<img src="{{ '/assets/img/breeze-ai/prompts.webp?v=1' | relative_url }}" width="656" height="362" class="!m-0 rounded-lg shadow-lg" alt="Prompts Screenshot"/>
+-->
+
+## AI Assistant
+
+Once a prompt is assigned to a field, an AI button appears next to that field on
+the product, category and CMS page edit forms. The button opens a chat popup ---
+pick a predefined prompt or type your own request, keep refining the answer in
+the same conversation, then click _Apply_ to write the result into the field.
+
+<!-- TODO: screenshot --- product edit page with the AI Assistant popup open over the Description field
+<img src="{{ '/assets/img/breeze-ai/ai-assistant.webp?v=1' | relative_url }}" width="656" height="362" class="!m-0 rounded-lg shadow-lg" alt="AI Assistant Screenshot"/>
+-->
+
+## AI Bulk Action
+
+Bulk generation is available under _Swissup > Breeze AI > AI Bulk Action_ menu.
+Select the products or categories in the grid, choose the skill --- _generate_ or
+_translate_ --- pick the fields, prompts and target store views, and submit.
+
+The jobs are dispatched to a Magento message queue, so the admin session isn't
+blocked and the progress can be watched under _System > Bulk Actions_. The
+consumer has to be running:
+
+```bash
+bin/magento queue:consumers:start swissup.breezeai.product.attribute.update.consumer
+```
+
+<!-- TODO: screenshot --- Swissup > Breeze AI > AI Bulk Action page with the product grid and the field/prompt form
+<img src="{{ '/assets/img/breeze-ai/bulk-action.webp?v=1' | relative_url }}" width="656" height="362" class="!m-0 rounded-lg shadow-lg" alt="AI Bulk Action Screenshot"/>
+-->
+
+## Translation
+
+Translation is a skill of its own, not a separate screen. It reads the default
+value of an attribute, translates it into the locale of the target store view
+and writes the result back to that store view --- available both from the AI
+Assistant popup and from AI Bulk Action.
+
+## MCP Server
+
+Breeze AI also works the other way around: instead of calling a model from the
+admin, it lets an AI coding agent --- Claude Code, Cursor, Cline, Windsurf ---
+call the store. The endpoint is `POST /rest/V1/breezeai/mcp` and it exposes four
+tools: `generate`, `translate`, `list_prompts` and `graphql` for read-only
+catalog access.
+
+The endpoint is enabled by default. To register an agent, generate a token:
+
+```bash
+bin/magento breezeai:mcp:setup
+```
+
+The command creates a permanent, revocable integration scoped to
+`Swissup_BreezeAi::manage` and prints a ready-to-paste connection command. On
+Magento 2.4.4+ integration tokens have to be allowed as bearer tokens:
+
+```bash
+bin/magento config:set oauth/consumer/enable_integration_as_bearer 1
+bin/magento cache:flush
+```
+
+The endpoint can be switched off, and the GraphQL URL used by the `graphql` tool
+can be overridden, under _Stores > Configuration > Swissup > Breeze AI > MCP
+Server_ --- the override is needed when the server can't reach itself by its
+public URL, for example with Varnish in front or inside docker.
+
+<!-- TODO: screenshot --- Stores > Configuration > Swissup > Breeze AI section (General + MCP Server groups)
+<img src="{{ '/assets/img/breeze-ai/mcp-server.webp?v=1' | relative_url }}" width="656" height="362" class="!m-0 rounded-lg shadow-lg" alt="MCP Server Screenshot"/>
+-->
+
+## Store discoverability
+
+Two read-only endpoints help external AI agents and crawlers understand the
+store without any configuration: `/llms.txt` describes the store in plain text,
+and `/.well-known/ai-plugin.json` advertises the GraphQL API as a plugin
+manifest.


### PR DESCRIPTION
Adds a Breeze AI docs page, requested in the Basecamp task "Breezepage": create a page like https://breezefront.com/docs/live-editor for Breeze AI.

New file: `collections/_core-concepts/breeze-ai.md` → `/docs/breeze-ai`

## Collection and order

`_core-concepts`, `order: 900`.

- `_extensions` only holds a generated `index.md` (`{% include docs/extensions.html %}`), so it is not a home for hand-written pages.
- Existing `_core-concepts` order values are 100, 300, 400, 450, 500, 700, 800 (Live Editor). 900 is free and places the page directly after Live Editor.
- The sidebar is generated from the collection, so nothing else needs editing.

## Page shape

Follows `collections/_core-concepts/live-editor.md`: front matter, `# Breeze AI`, TOC, an About section with a bulleted list of the parts, then one `##` section per component with the `Swissup > Breeze AI > X` menu path.

Documented parts, all verified against the module source rather than its README:

| Part | Where it lives |
|---|---|
| AI Models | `Swissup > Breeze AI > Models` — OpenAI, Claude, Gemini |
| Prompts | `Swissup > Breeze AI > Prompts` |
| AI Assistant | inline button and chat popup on product, category and CMS page edit forms |
| AI Bulk Action | `Swissup > Breeze AI > AI Bulk Action` — queue-backed |
| Translation | a skill used by the Assistant and Bulk Action, not a separate screen |
| MCP Server | `POST /rest/V1/breezeai/mcp`, plus `bin/magento breezeai:mcp:setup` |
| Discoverability | `/llms.txt` and `/.well-known/ai-plugin.json` |

Two notes on accuracy:

- The module README describes bulk generation as a `Catalog > Products` mass action. No such mass action exists in the code — the current implementation is the dedicated `bulkaction/edit` page with its own product and category grids. The page documents the code.
- Unshipped work is left out: issues #23 (AI landing page builder), #39 (MCP OAuth 2.0 and SSE) and #8 (backup and rollback).

## Free vs Enterprise

Breeze AI is documented as part of Breeze Enterprise, so unlike Theme Editor it gets no open-source link. Basis: the `breezefront/module-breeze-ai` repo is private, the `swissup/breeze-enterprise` metapackage requires `swissup/module-breeze-ai: ^1.0.5`, and this site's own changelog already announces it as included with Breeze Enterprise (`collections/_landings/updates.md`).

## Screenshots — still to do

No screenshots are included, and no broken image paths are referenced. Five `<img>` tags are left commented out at their intended positions with the final asset paths, the `!m-0 rounded-lg shadow-lg` class list and `width="656"`, so each one is enabled by uncommenting it once the file exists.

To capture, saved as webp under `assets/img/breeze-ai/`:

1. `models.webp` — the Models grid, or the model form showing the provider select
2. `prompts.webp` — the Prompts grid, or the prompt form with its field assignment
3. `ai-assistant.webp` — a product edit page with the AI Assistant popup open over Description
4. `bulk-action.webp` — the AI Bulk Action page with the product grid and the field and prompt form
5. `mcp-server.webp` — `Stores > Configuration > Swissup > Breeze AI`, General and MCP Server groups

The `height` attribute in each commented tag is a placeholder and must be set to the real cropped height — Live Editor uses 362 and 324, so it differs per screenshot.

Task: https://app.basecamp.com/6059321/buckets/44088164/todos/10034267607

🤖 Generated with [Claude Code](https://claude.com/claude-code)