### PR TITLE
Correct the AI Bulk Action flow on the Breeze AI page

### DIFF
--- a/collections/_core-concepts/breeze-ai.md
+++ b/collections/_core-concepts/breeze-ai.md
@@ -62,12 +62,21 @@ the same conversation, then click _Apply_ to write the result into the field.
 ## AI Bulk Action
 
 Bulk generation is available under _Swissup > Breeze AI > AI Bulk Action_ menu.
-Select the products or categories in the grid, choose the skill --- _generate_ or
-_translate_ --- pick the fields, prompts and target store views, and submit.
+The page is a step-by-step form, and every step only appears once the previous
+one is answered:
 
-The jobs are dispatched to a Magento message queue, so the admin session isn't
-blocked and the progress can be watched under _System > Bulk Actions_. The
-consumer has to be running:
+ 1. _Select content type_ --- products or categories.
+ 2. _Select AI task_ --- _Generate Content_ or _Translate_.
+ 3. _Select store view_ --- the language and scope of the operation. Translate
+    asks for a source and a target store view instead of a single one.
+ 4. _Select fields_ --- the attributes to process, with a prompt picked per
+    field.
+ 5. _Select items_ --- the grid, where the products or categories are picked
+    by hand or narrowed down with filters.
+
+Then hit _Run_. The jobs are dispatched to a Magento message queue, so the admin
+session isn't blocked and the progress can be watched under _System > Bulk
+Actions_. The consumer has to be running:
 
 ```bash
 bin/magento queue:consumers:start swissup.breezeai.product.attribute.update.consumer
@@ -79,10 +88,10 @@ bin/magento queue:consumers:start swissup.breezeai.product.attribute.update.cons
 
 ## Translation
 
-Translation is a skill of its own, not a separate screen. It reads the default
-value of an attribute, translates it into the locale of the target store view
-and writes the result back to that store view --- available both from the AI
-Assistant popup and from AI Bulk Action.
+Translation is a skill of its own, not a separate screen. It reads the value of
+an attribute in the source store view, translates it into the locale of the
+target store view and writes the result back to that store view --- available
+both from the AI Assistant popup and from AI Bulk Action.
 
 ## MCP Server
 


### PR DESCRIPTION
Follow-up to #12. I walked the actual admin screens on a local 2.4.8 install and the AI Bulk Action paragraph was wrong about the order of operations.

## What was wrong

The page said the products or categories are picked in the grid first, then the skill and fields. In reality the screen is a step-by-step form where each step only appears once the previous one is answered, and the grid is **last**:

1. Select content type — Products / Categories
2. Select AI task — Generate Content / Translate
3. Select store view — Translate asks for a source and a target store view instead of one
4. Select fields — attributes to process, one prompt per field
5. Select items — the grid, by hand or via filters

The submit button is labelled **Run**. The grid does not render at all until a prompt has been selected, which is why the earlier description read backwards.

Labels are taken from `view/adminhtml/templates/bulk_action/edit.phtml` rather than transcribed from the screen, so they match the source strings exactly.

## Translation section

Also corrected: it claimed translation reads "the default value" of an attribute. Translate takes an explicit source store view, so it reads the value in that store view, not the default one.

## Not in this PR

Screenshots are still missing — the five `<img>` tags stay commented out. Two things need to happen first, and both are worth flagging separately:

- The module checkout used for this walkthrough sits on `feat/ai-landing-page-builder`, one commit past the `1.0.11` tag. On that branch step 2 offers a third option, **Build Landing Page** (breezefront/module-breeze-ai#23), which is not in any release. Screenshots have to be taken from the released tag, otherwise they document a feature nobody has.
- The MCP section describes the `graphql` tool as read-only. That is the tool's own description string, not something the code enforces — `McpServer::graphql()` posts the query straight through to `/graphql`. Worth either enforcing it or rewording the page; not changed here because it is a claim about behaviour, not a typo.

Task: https://app.basecamp.com/6059321/buckets/44088164/todos/10034267607

🤖 Generated with [Claude Code](https://claude.com/claude-code)