### PR TITLE
Say how the MCP graphql tool is read-only

### DIFF
--- a/collections/_core-concepts/breeze-ai.md
+++ b/collections/_core-concepts/breeze-ai.md
@@ -101,6 +101,12 @@ call the store. The endpoint is `POST /rest/V1/breezeai/mcp` and it exposes four
 tools: `generate`, `translate`, `list_prompts` and `graphql` for read-only
 catalog access.
 
+`graphql` forwards the query to the storefront GraphQL endpoint without an auth
+header, so it sees what a guest sees. Read-only there is enforced rather than
+assumed --- the tool reads the operation type of the document and rejects anything
+but `query` and `fragment` definitions, so a mutation never reaches the store.
+`generate` and `translate` do write, which is what they are for.
+
 The endpoint is enabled by default. To register an agent, generate a token:
 
 ```bash


### PR DESCRIPTION
The **MCP Server** section says the endpoint exposes `graphql` "for read-only catalog access". Until breezefront/module-breeze-ai#43 that was not true: `McpServer::graphql()` forwarded the query to the storefront GraphQL endpoint verbatim, with no operation check and no auth header — so it ran in guest scope, where Magento accepts `createEmptyCart`, `addProductsToCart`, `setGuestEmail` and friends. An agent could mutate store state through a tool the page called read-only.

The module PR fixes the code rather than the wording: the tool now reads the operation type of the document and rejects anything but `query` and `fragment` definitions. So "read-only" stays — this PR just says what backs it, and names the scope the query actually runs in.

```
`graphql` forwards the query to the storefront GraphQL endpoint without an auth
header, so it sees what a guest sees. Read-only there is enforced rather than
assumed --- the tool reads the operation type of the document and rejects anything
but `query` and `fragment` definitions, so a mutation never reaches the store.
`generate` and `translate` do write, which is what they are for.
```

One paragraph added, nothing removed. kramdown `---` for em dashes, sentence-case, wrapped to match the surrounding prose.

## ⚠️ Merge order

Depends on **breezefront/module-breeze-ai#43**. Merging here deploys to GitHub Pages immediately, so this should land **after** the module fix is merged and tagged in a release — otherwise the page describes enforcement that isn't in anyone's `vendor/` yet.

Relevant because MCP is about to be promoted publicly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)